### PR TITLE
Add user profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+agvenv/
+__pycache__/
+spent.db

--- a/Community Version/spent.py
+++ b/Community Version/spent.py
@@ -1,6 +1,7 @@
 import sqlite3
 from datetime import datetime
 
+
 def init():
     '''
     Initialize a new database to store the
@@ -20,6 +21,7 @@ def init():
     conn.commit()
     conn.close()
 
+
 def log(amount, category, message=''):
     '''
     logs the expenditure in the database.
@@ -35,6 +37,7 @@ def log(amount, category, message=''):
     c.execute(sql, data)
     conn.commit()
     conn.close()
+
 
 def view(category=None):
     '''

--- a/Community Version/spent_driver.py
+++ b/Community Version/spent_driver.py
@@ -1,0 +1,45 @@
+#spent_driver.py use [<profile_name>]
+usage = '''
+
+Expense Tracker CLI.
+
+Usage:
+  spent_driver.py init
+  spent_driver.py view [<view_profile>] [<view_category>] 
+  spent_driver.py <amount> <category> [<profile_name>] [<message>] 
+
+'''
+
+from docopt import docopt
+from spent import *
+from tabulate import tabulate
+
+args = docopt(usage)
+#print(args)
+
+if args['init']:
+    init()
+    print("User Profile Created")
+
+if args['view']:
+    category = args['<view_category>']
+    profile = args['<view_profile>']
+    if profile:
+        amount, results = view(category, profile)
+
+    else:
+        amount, results = view(category)
+    print("Total expense: ", amount)
+    print(tabulate(results))
+
+if args['<amount>']:
+    try:
+        amount = float(args['<amount>'])
+        if(args['<profile_name>']):
+            log(amount, args['<category>'],args['<message>'],args['<profile_name>'])
+        else:
+            log(amount, args['<category>'],args['<message>'])
+
+
+    except:
+        print(usage)

--- a/Community Version/spent_driver.py
+++ b/Community Version/spent_driver.py
@@ -1,21 +1,21 @@
-#spent_driver.py use [<profile_name>]
+# spent_driver.py use [<profile_name>]
+from tabulate import tabulate
+from spent import *
+from docopt import docopt
 usage = '''
 
 Expense Tracker CLI.
 
 Usage:
   spent_driver.py init
-  spent_driver.py view [<view_profile>] [<view_category>] 
-  spent_driver.py <amount> <category> [<profile_name>] [<message>] 
+  spent_driver.py view [<view_profile>] [<view_category>]
+  spent_driver.py <amount> <category> [<profile_name>] [<message>]
 
 '''
 
-from docopt import docopt
-from spent import *
-from tabulate import tabulate
 
 args = docopt(usage)
-#print(args)
+# print(args)
 
 if args['init']:
     init()
@@ -36,10 +36,12 @@ if args['<amount>']:
     try:
         amount = float(args['<amount>'])
         if(args['<profile_name>']):
-            log(amount, args['<category>'],args['<message>'],args['<profile_name>'])
+            log(amount,
+                args['<category>'],
+                args['<message>'],
+                args['<profile_name>'])
         else:
-            log(amount, args['<category>'],args['<message>'])
+            log(amount, args['<category>'], args['<message>'])
 
-
-    except:
+    except BaseException:
         print(usage)

--- a/README.md
+++ b/README.md
@@ -38,9 +38,12 @@ $ spent init
 
 Logging an expense:
 ```sh
-$ spent <amount> <category> [<message>]
+$ spent <amount> <category> [<profile>] [<message>]
 ```
 `message` is optional.
+`profile` is optional.
+
+If profile is not specified the default user profile is "home".
 
 For example,
 ```sh
@@ -48,32 +51,39 @@ $ spent 50 food "snacks in the evening"
 $ spent 100 transport
 ```
 
-Viewing your expenditure:
+Viewing your expenditure for all profiles:
 ```sh
-spent_driver.py view [<view_category>]
+spent_driver.py view
 ```
 For example,
 ```sh
-$ spent view
-$ spent view food
+$ spent_driver.py view
 ```
 
 The first command shows you your total expenditure, along with a list of all transactions you've made.
 
-The second one is more streamlined, and gives you the details for the sepecified category.
+Viewing your expenditure for a particular user profile:
+```sh
+$ spent_driver.py view <user_profile> <category>
+```
+For example,
+```sh
+$ spent_driver.py view work transport
+```
+The second one is more streamlined, and gives you the details for the specified user profile and category.
 
 *An example output*
 ```sh
-$ spent view
-Total expense: 5200
-----  ---------  ----------------------  --------------------------
- 100  food       None                    2018-12-02 15:41:17.823609
- 200  cinema     None                    2018-12-02 15:41:22.958207
- 300  taxi       None                    2018-12-02 15:41:28.565593
- 100  groceries  having friends over     2018-12-02 15:42:40.332875
-1500  travel     air tickets to go home  2018-12-02 15:43:10.711194
-3000  rent       security deposit        2018-12-02 15:44:28.739984
-----  ---------  ----------------------  --------------------------
+$ spent_driver.py view
+Total expense:  5200
+----  ----  ---------  ----------------------  --------------------------
+work   100  food                               2019-12-21 06:51:22.323043
+home   200  cinema                             2019-12-21 06:51:41.695574
+work   300  taxi                               2019-12-21 06:52:04.985462
+home   100  groceries                          2019-12-21 06:52:18.811124
+work  1500  travel     air tickets to go home  2019-12-21 06:53:04.812908
+home  3000  rent       security deposit        2019-12-21 06:53:46.783464
+----  ----  ---------  ----------------------  --------------------------
 ```
 
 # Contributions

--- a/spent.py
+++ b/spent.py
@@ -1,6 +1,7 @@
 import sqlite3 as db
 from datetime import datetime
 
+
 def init():
     '''
     Initialize a new database to store the
@@ -20,7 +21,8 @@ def init():
     cur.execute(sql)
     conn.commit()
 
-def log(amount, category, message="",profile="home"):
+
+def log(amount, category, message="", profile="home"):
     '''
     logs the expenditure in the database.
     amount: number
@@ -35,7 +37,8 @@ def log(amount, category, message="",profile="home"):
     cur.execute(sql, data)
     conn.commit()
 
-def view(category=None,profile=None):
+
+def view(category=None, profile=None):
     '''
     Returns a list of all expenditure incurred, and the total expense.
     If a category is specified, it only returns info from that
@@ -46,10 +49,10 @@ def view(category=None,profile=None):
     if category:
         sql = '''
         select * from expenses where (category = '{}' and profile = '{}')
-        '''.format(category,profile)
+        '''.format(category, profile)
         sql2 = '''
         select sum(amount) from expenses where (category = '{}' and profile = '{}')
-        '''.format(category,profile)
+        '''.format(category, profile)
     elif profile:
         sql = '''
         select * from expenses where profile = '{}'
@@ -64,8 +67,8 @@ def view(category=None,profile=None):
         '''
         sql2 = '''
         select sum(amount) from expenses
-        '''     
-    
+        '''
+
     cur.execute(sql)
     results = cur.fetchall()
     cur.execute(sql2)

--- a/spent.py
+++ b/spent.py
@@ -10,6 +10,7 @@ def init():
     cur = conn.cursor()
     sql = '''
     create table if not exists expenses (
+        profile string,
         amount number,
         category string,
         message string,
@@ -19,7 +20,7 @@ def init():
     cur.execute(sql)
     conn.commit()
 
-def log(amount, category, message=""):
+def log(amount, category, message="",profile="home"):
     '''
     logs the expenditure in the database.
     amount: number
@@ -27,14 +28,14 @@ def log(amount, category, message=""):
     message: (optional) string
     '''
     date = str(datetime.now())
-    data = (amount, category, message, date)
+    data = (profile, amount, category, message, date)
     conn = db.connect("spent.db")
     cur = conn.cursor()
-    sql = 'INSERT INTO expenses VALUES (?, ?, ?, ?)'
+    sql = 'INSERT INTO expenses VALUES (?, ?, ?, ?, ?)'
     cur.execute(sql, data)
     conn.commit()
 
-def view(category=None):
+def view(category=None,profile=None):
     '''
     Returns a list of all expenditure incurred, and the total expense.
     If a category is specified, it only returns info from that
@@ -44,18 +45,27 @@ def view(category=None):
     cur = conn.cursor()
     if category:
         sql = '''
-        select * from expenses where category = '{}'
-        '''.format(category)
+        select * from expenses where (category = '{}' and profile = '{}')
+        '''.format(category,profile)
         sql2 = '''
-        select sum(amount) from expenses where category = '{}'
-        '''.format(category)
+        select sum(amount) from expenses where (category = '{}' and profile = '{}')
+        '''.format(category,profile)
+    elif profile:
+        sql = '''
+        select * from expenses where profile = '{}'
+        '''.format(profile)
+        sql2 = '''
+        select sum(amount) from expenses where profile = '{}'
+        '''.format(profile)
+
     else:
         sql = '''
         select * from expenses
-        '''.format(category)
+        '''
         sql2 = '''
         select sum(amount) from expenses
-        '''.format(category)
+        '''     
+    
     cur.execute(sql)
     results = cur.fetchall()
     cur.execute(sql2)

--- a/spent_driver.py
+++ b/spent_driver.py
@@ -15,7 +15,7 @@ from spent import *
 from tabulate import tabulate
 
 args = docopt(usage)
-print(args)
+#print(args)
 
 if args['init']:
     init()

--- a/spent_driver.py
+++ b/spent_driver.py
@@ -1,3 +1,6 @@
+from tabulate import tabulate
+from spent import *
+from docopt import docopt
 usage = '''
 Expense Tracker CLI.
 Usage:
@@ -6,9 +9,6 @@ Usage:
   spent_driver.py <amount> <category> [<message>]
 '''
 
-from docopt import docopt
-from spent import *
-from tabulate import tabulate
 
 args = docopt(usage)
 
@@ -26,5 +26,5 @@ if args['<amount>']:
     try:
         amount = float(args['<amount>'])
         log(amount, args['<category>'], args['<message>'])
-    except:
+    except BaseException:
         print(usage)

--- a/spent_driver.py
+++ b/spent_driver.py
@@ -1,13 +1,9 @@
-#spent_driver.py use [<profile_name>]
 usage = '''
-
 Expense Tracker CLI.
-
 Usage:
   spent_driver.py init
-  spent_driver.py view [<view_profile>] [<view_category>] 
-  spent_driver.py <amount> <category> [<profile_name>] [<message>] 
-
+  spent_driver.py view [<view_category>]
+  spent_driver.py <amount> <category> [<message>]
 '''
 
 from docopt import docopt
@@ -15,7 +11,6 @@ from spent import *
 from tabulate import tabulate
 
 args = docopt(usage)
-#print(args)
 
 if args['init']:
     init()
@@ -23,24 +18,13 @@ if args['init']:
 
 if args['view']:
     category = args['<view_category>']
-    profile = args['<view_profile>']
-    if profile:
-        amount, results = view(category, profile)
-
-    else:
-        amount, results = view(category)
+    amount, results = view(category)
     print("Total expense: ", amount)
     print(tabulate(results))
 
 if args['<amount>']:
     try:
         amount = float(args['<amount>'])
-        if(args['<profile_name>']):
-            log(amount, args['<category>'],args['<message>'],args['<profile_name>'])
-        else:
-            log(amount, args['<category>'],args['<message>'])
-
-
+        log(amount, args['<category>'], args['<message>'])
     except:
         print(usage)
-

--- a/spent_driver.py
+++ b/spent_driver.py
@@ -1,11 +1,12 @@
+#spent_driver.py use [<profile_name>]
 usage = '''
 
 Expense Tracker CLI.
 
 Usage:
   spent_driver.py init
-  spent_driver.py view [<view_category>]
-  spent_driver.py <amount> <category> [<message>]
+  spent_driver.py view [<view_profile>] [<view_category>] 
+  spent_driver.py <amount> <category> [<profile_name>] [<message>] 
 
 '''
 
@@ -14,6 +15,7 @@ from spent import *
 from tabulate import tabulate
 
 args = docopt(usage)
+print(args)
 
 if args['init']:
     init()
@@ -21,13 +23,24 @@ if args['init']:
 
 if args['view']:
     category = args['<view_category>']
-    amount, results = view(category)
+    profile = args['<view_profile>']
+    if profile:
+        amount, results = view(category, profile)
+
+    else:
+        amount, results = view(category)
     print("Total expense: ", amount)
     print(tabulate(results))
 
 if args['<amount>']:
     try:
         amount = float(args['<amount>'])
-        log(amount, args['<category>'], args['<message>'])
+        if(args['<profile_name>']):
+            log(amount, args['<category>'],args['<message>'],args['<profile_name>'])
+        else:
+            log(amount, args['<category>'],args['<message>'])
+
+
     except:
         print(usage)
+


### PR DESCRIPTION
This PR tries to implement the user profile feature mentioned in issue #1 and tries to address the changes requested in PR #7. 
Things implemented:
1. spent_driver.py updated to work with the new API supporting user profile
2. A default user profile of "home" is used when profile is not specified to the driver.

Things not implemented:
1. A command for setting up a global default user profile to log our expenses as mentioned in #7 .
```sh
spent use <user_profile>
``` 